### PR TITLE
Encode ID in /v2/identities call

### DIFF
--- a/src/idn-client.ts
+++ b/src/idn-client.ts
@@ -105,7 +105,8 @@ export class IDNClient {
 
     async getAccountDetails(id: string): Promise<AxiosResponse> {
         const accessToken = await this.getAccessToken()
-        const url: string = `/v2/identities/${id}`
+        const encodedId = encodeURIComponent(id)
+        const url: string = `/v2/identities/${encodedId}`
 
         let request: AxiosRequestConfig = {
             method: 'get',


### PR DESCRIPTION
Encode the ID since it's in the URL, and Identity names can contain characters such as # since they can be included in the Identity name. I found this out with an Azure B2B-based identity where the Identity name was something such as `alex.dunker_edgile.com#EXT#@M365x19437813.onmicrosoft.com` . The v2 Identities API will fail if the ID is not encoded.