### PR TITLE
Working Enable and Disable Operation + Account Enable Check improved

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto

--- a/connector-spec.json
+++ b/connector-spec.json
@@ -36,19 +36,6 @@
                     "required": true
                 }
             ]
-        },
-        {
-            "type": "section",
-            "sectionTitle": "Configuration details",
-            "sectionHelpMessage": "Add your configuration details here",
-            "items": [
-                {
-                    "key": "enableRetries",
-                    "label": "Number of retries for enable/disable account operations",
-                    "type": "number",
-                    "required": true
-                }
-            ]
         }
     ],
     "accountSchema": {

--- a/connector-spec.json
+++ b/connector-spec.json
@@ -74,7 +74,7 @@
                 "description": ""
             },
             {
-                "name": "enabled",
+                "name": "disabled",
                 "type": "boolean",
                 "description": ""
             },

--- a/connector-spec.json
+++ b/connector-spec.json
@@ -74,7 +74,7 @@
                 "description": ""
             },
             {
-                "name": "disabled",
+                "name": "enabled",
                 "type": "boolean",
                 "description": ""
             },

--- a/src/idn-client.ts
+++ b/src/idn-client.ts
@@ -343,7 +343,7 @@ export class IDNClient {
 
     async enableAccount(id: string): Promise<AxiosResponse> {
         const accessToken = await this.getAccessToken()
-        const url: string = `beta/identities-accounts/enable`
+        const url: string = `beta/identities-accounts/${id}/enable`
 
         let request: AxiosRequestConfig = {
             method: 'post',
@@ -351,12 +351,8 @@ export class IDNClient {
             url,
             headers: {
                 Authorization: `Bearer ${accessToken}`,
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
             },
-            data: {
-                "identityIds": [id],
-            },
+            data: null,
         }
 
         return await axios(request)
@@ -364,20 +360,16 @@ export class IDNClient {
 
     async disableAccount(id: string): Promise<AxiosResponse> {
         const accessToken = await this.getAccessToken()
-        const url: string = `beta/identities-accounts/disable`
+        const url: string = `beta/identities-accounts/${id}/disable`
 
         let request: AxiosRequestConfig = {
             method: 'post',
             baseURL: this.idnUrl,
             url,
             headers: {
-                Authorization: `Bearer ${accessToken}`,
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
+                Authorization: `Bearer ${accessToken}`
             },
-            data: {
-                "identityIds": [id],
-            },
+            data: null,
         }
         return await axios(request)
     }

--- a/src/idn-client.ts
+++ b/src/idn-client.ts
@@ -343,7 +343,7 @@ export class IDNClient {
 
     async enableAccount(id: string): Promise<AxiosResponse> {
         const accessToken = await this.getAccessToken()
-        const url: string = `beta/identities-accounts/${id}/enable`
+        const url: string = `/beta/identities-accounts/${id}/enable`
 
         let request: AxiosRequestConfig = {
             method: 'post',
@@ -360,7 +360,7 @@ export class IDNClient {
 
     async disableAccount(id: string): Promise<AxiosResponse> {
         const accessToken = await this.getAccessToken()
-        const url: string = `beta/identities-accounts/${id}/disable`
+        const url: string = `/beta/identities-accounts/${id}/disable`
 
         let request: AxiosRequestConfig = {
             method: 'post',

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export const connector = async () => {
 
     const SLEEP: number = 2000
     const workgroupRegex = /.+-.+-.+-.+-.+/
+    const EXCLUDED_ROLES = ['AUDITOR', 'DASHBOARD']
 
     function sleep(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms))
@@ -117,10 +118,12 @@ export const connector = async () => {
             const response1: AxiosResponse = await client.roleAggregation()
             const response2: AxiosResponse = await client.workgroupAggregation()
             for (const r of response1.data) {
-                const role: Role = new Role(r)
+                if (!EXCLUDED_ROLES.includes(r.value)) {
+                    const role: Role = new Role(r)
 
-                logger.info(role)
-                res.send(role)
+                    logger.info(role)
+                    res.send(role)
+                }
             }
             for (const w of response2.data) {
                 const workgroup: Workgroup = new Workgroup(w)

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,22 +199,21 @@ export const connector = async () => {
             logger.info(input)
             const workgroups: any[] = await getWorkgroups()
             const account: Account = await buildAccount(input.identity, workgroups)
-
-            const response = await client.disableAccount(account.attributes.externalId as string)
-            account.attributes.enabled = false
-
+            account.attributes.enabled= false
             logger.info(account)
             res.send(account)
+            const response = await client.disableAccount(account.attributes.externalId as string)
+
+
+
         })
         .stdAccountEnable(async (context: Context, input: any, res: Response<any>) => {
             logger.info(input)
             const workgroups: any[] = await getWorkgroups()
             const account: Account = await buildAccount(input.identity, workgroups)
-
-            const response = await client.enableAccount(account.attributes.externalId as string)
-            account.attributes.enabled = false
-
+            account.attributes.enabled = true
             logger.info(account)
             res.send(account)
+            const response = await client.enableAccount(account.attributes.externalId as string)
         })
 }

--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -7,6 +7,11 @@ export class Account {
     disabled: boolean
 
     constructor(object: any) {
+        var enablecheck = true
+        if(object.status  == "DISABLED")
+        {
+            enablecheck = false
+        }
         this.attributes = {
             id: object.id,
             externalId: object.externalId,
@@ -14,7 +19,7 @@ export class Account {
             firstName: object.attributes.firstname,
             lastName: object.attributes.lastname,
             displayName: object.name,
-            enabled: !object.inactive,
+            enabled: enablecheck,
             groups: object.role,
         }
         this.disabled = !this.attributes.enabled


### PR DESCRIPTION
1. Making the enable and disable call after the res.send (The idnow api block does not effect the operations)
![image](https://user-images.githubusercontent.com/61413897/233428886-e0e44709-039a-44ee-b4fa-369791f4f520.png)

2. Made updates to model/account using status object from v3 search. (Using inactive object from v3 search does not work as even for a disabled identity, it remains false.
![image](https://user-images.githubusercontent.com/61413897/233429729-f7d06f6b-675d-48fb-ad1e-92e88489a80e.png)
